### PR TITLE
feat(titles): add a title to each type

### DIFF
--- a/index.json
+++ b/index.json
@@ -1,37 +1,48 @@
 {
   "types": {
     "feat": {
-      "description": "A new feature"
+      "description": "A new feature",
+      "title": "Features"
     },
     "fix": {
-      "description": "A bug fix"
+      "description": "A bug fix",
+      "title": "Bug Fixes"
     },
     "docs": {
-      "description": "Documentation only changes"
+      "description": "Documentation only changes",
+      "title": "Documentation"
     },
     "style": {
-      "description": "Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)"
+      "description": "Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)",
+      "title": "Styles"
     },
     "refactor": {
-      "description": "A code change that neither fixes a bug nor adds a feature"
+      "description": "A code change that neither fixes a bug nor adds a feature",
+      "title": "Code Refactoring"
     },
     "perf": {
-      "description": "A code change that improves performance"
+      "description": "A code change that improves performance",
+      "title": "Performance Improvements"
     },
     "test": {
-      "description": "Adding missing tests or correcting existing tests"
+      "description": "Adding missing tests or correcting existing tests",
+      "title": "Tests"
     },
     "build": {
-      "description": "Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)"
+      "description": "Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)",
+      "title": "Builds"
     },
     "ci": {
-      "description": "Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)"
+      "description": "Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)",
+      "title": "Continuous Integrations"
     },
     "chore": {
-      "description": "Other changes that don't modify src or test files"
+      "description": "Other changes that don't modify src or test files",
+      "title": "Chores"
     },
     "revert": {
-      "description": "Reverts a previous commit"
+      "description": "Reverts a previous commit",
+      "title": "Reverts"
     }
   }
 }


### PR DESCRIPTION
I would like to use this to replace https://github.com/conventional-changelog/conventional-changelog/blob/master/packages/conventional-changelog-angular/index.js#L50-L70. I think it makes sense to add them here so there's more metadata to describe the types.