### PR TITLE
feat!: remove improvement

### DIFF
--- a/index.json
+++ b/index.json
@@ -8,10 +8,6 @@
       "description": "A bug fix",
       "title": "Bug Fixes"
     },
-    "improvement": {
-      "description": "An improvement to a current feature",
-      "title": "Improvements"
-    },
     "docs": {
       "description": "Documentation only changes",
       "title": "Documentation"


### PR DESCRIPTION
I'm proposing we consider removing the `improvement` type, which is no longer recommended in the Conventional Commits spec. It was [in their `1.0.0-beta.4` release](https://github.com/conventional-commits/conventionalcommits.org/blame/a3f54496f57dfaf831447e21cd4c43a9cd7fc84e/content/v1.0.0-beta.4/index.md#L39), but [removed in `1.0.0`](https://github.com/conventional-commits/conventionalcommits.org/blame/a3f54496f57dfaf831447e21cd4c43a9cd7fc84e/content/v1.0.0/index.md#L42).

It was added here in #13, as did other tools like https://github.com/conventional-changelog/commitlint/pull/832. But this addition was questioned in #15, which I'd agreed with per my comments https://github.com/commitizen/conventional-commit-types/pull/13#pullrequestreview-287730397 and https://github.com/commitizen/conventional-commit-types/issues/15#issuecomment-548606772.

This also caused some other turbulence with other tools, such as https://github.com/commitizen/cz-cli/issues/681 and https://github.com/conventional-changelog/commitlint/pull/832.

Maybe it's too late? 🤷‍♂ 

