### PR TITLE
feat: add 'doc' as the alias of 'docs'

### DIFF
--- a/index.json
+++ b/index.json
@@ -8,6 +8,10 @@
       "description": "A bug fix",
       "title": "Bug Fixes"
     },
+    "doc": {
+      "description": "Documentation only changes",
+      "title": "Documentation"
+    },
     "docs": {
       "description": "Documentation only changes",
       "title": "Documentation"


### PR DESCRIPTION
Since there is 'test' but not 'tests', I think it would be great
to add 'doc' beside 'docs'.